### PR TITLE
Fix open error of NetCDF

### DIFF
--- a/configure
+++ b/configure
@@ -18968,13 +18968,13 @@ echo ---
   LDFLAGS="-L${ga_supplib_dir}/lib "
   LIBS="$LIBS "
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lpng15" >&5
-$as_echo_n "checking for main in -lpng15... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lpng" >&5
+$as_echo_n "checking for main in -lpng... " >&6; }
 if ${ac_cv_lib_png15_main+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpng15  $LIBS"
+LIBS="-lpng  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -19009,13 +19009,13 @@ fi
   LIBS=$ga_saved_libs
 
 if test "$have_png" != "yes" ; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lpng15" >&5
-$as_echo_n "checking for main in -lpng15... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lpng" >&5
+$as_echo_n "checking for main in -lpng... " >&6; }
 if ${ac_cv_lib_png15_main+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpng15  $LIBS"
+LIBS="-lpng  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -20063,10 +20063,10 @@ if test "Z$ga_supplib_dir" != "Z" ; then
   ga_saved_cppflags=$CPPFLAGS
   ga_saved_ldflags=$LDFLAGS
   ga_saved_libs=$LIBS
-  CPPFLAGS="-I${ga_supplib_dir}/include"
+  CPPFLAGS="${CPPFLAGS} -I${ga_supplib_dir}/include"
   :
   CPPFLAGS="$CPPFLAGS "
-  LDFLAGS="-L${ga_supplib_dir}/lib "
+  LDFLAGS="${LDFLAGS} -L${ga_supplib_dir}/lib "
   LIBS="$LIBS "
 
     ac_fn_c_check_header_mongrel "$LINENO" "grib2.h" "ac_cv_header_grib2_h" "$ac_includes_default"
@@ -20106,7 +20106,7 @@ if test "x$ac_cv_lib_grib2c_main" = xyes; then :
 #        GA_SET_LIB_VAR([grib2_libs], [grib2c jasper png15 z])
 
   ga_lib_prefix='-l'
-  for ga_lib_name in grib2c jasper png15 z ; do
+  for ga_lib_name in grib2c jasper png z ; do
       grib2_libs="$grib2_libs ${ga_lib_prefix}${ga_lib_name}"
   done
 
@@ -20164,13 +20164,13 @@ fi
 $as_echo "$ac_cv_lib_grib2c_main" >&6; }
 if test "x$ac_cv_lib_grib2c_main" = xyes; then :
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lpng15" >&5
-$as_echo_n "checking for main in -lpng15... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for main in -lpng" >&5
+$as_echo_n "checking for main in -lpng... " >&6; }
 if ${ac_cv_lib_png15_main+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lpng15  $LIBS"
+LIBS="-lpng  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -20299,7 +20299,7 @@ $as_echo "$ac_cv_lib_jasper_main" >&6; }
 if test "x$ac_cv_lib_jasper_main" = xyes; then :
 
       ga_check_grib2="yes"
-      G2_LIBS="-lgrib2c -ljasper -lpng15 -lz"
+      G2_LIBS="-lgrib2c -ljasper -lpng -lz"
 
 fi
 

--- a/src/gasdf.c
+++ b/src/gasdf.c
@@ -920,7 +920,7 @@ cv_converter *converter=NULL;
 	  if (!temp_str) {
 	    trunc_point = strlen(time_units) ;
 	  } else {
-	    trunc_point = strlen(time_units)-strlen(temp_str)+1;
+	    trunc_point = strlen(time_units)-strlen(temp_str);
 	  }
 	  sz = trunc_point+1;
           trunc_units = (char *) galloc(sz,"trunc_units");


### PR DESCRIPTION
Calls to `utScan()` from `compare_units()` in `src/gasdf.c` cause errors due to an incorrect truncation.
I experienced errors with udunits2 and segmentation faults with udunits.

For example, the length of "`hours since`" is 11 and that of `temp_str` (starting from "` since`" with a leading white space is 6.
`trunc_units` should be terminated at  the white space between "`hours`" and "`since`", which is 5.
Therefore adding 1 add an extra white space to `trunc_units`.

In addition, I edited `configure` to remove version string from png and respect `CPPFLAGS` and `LDFLAGS` in finding wgrib2.
