### PR TITLE
Add missing GA_UNSET_FLAGS to netcdf check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -759,6 +759,7 @@ if test "$have_udunits" = "yes" ; then
         fi
       ])
     ])
+    GA_UNSET_FLAGS
   fi
 # check in system locations
   if test "$ga_dyn_supplibs" = "yes" ; then


### PR DESCRIPTION
The biggest side effect that I noticed was that CPPFLAGS was getting overwritten.