### PR TITLE
Add gxX.c to libgxpCairo_la_SOURCES for gxdXflush

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -37,7 +37,7 @@ src_gui = gagui.c gsgui.c
 endif
 
 if USECAIRO
-libgxpCairo_la_SOURCES = gxprint.c gxC.c
+libgxpCairo_la_SOURCES = gxprint.c gxC.c gxX.c
 libgxdCairo_la_SOURCES = gxX.c gxC.c
 endif
 


### PR DESCRIPTION
While building the Fedora grads package for EL8, I got the following run time error:
```
/usr/lib64/libgxpCairo.so: undefined symbol: gxdXflush
```
This seems to fix it.