### PR TITLE
Support noleap calendar in NetCDF with sdfopen

### DIFF
--- a/src/grads.c
+++ b/src/grads.c
@@ -48,7 +48,7 @@ void write_command_log(char *logfile);
 
 static struct gaupb *upba=NULL;     /* Anchor for user defined plug-in */
 char *gxgnam(char *);               /* This is also in gx.h */
-static struct gacmn gcmn;  
+struct gacmn gcmn;
 static struct gawgds wgds; 
 extern struct gamfcmn mfcmn;
 

--- a/src/grads.h
+++ b/src/grads.h
@@ -1299,6 +1299,7 @@ gaint find_dim(struct gafile *, char *);
 void  handle_error(gaint);
 void  close_sdf(struct gafile *);
 gaint decode_standard_time(gadouble, gaint *, gaint *, gaint *, gaint *, gaint *, gafloat *);
+gaint advance_cal365_time(gadouble, char*, gaint *, gaint *, gaint *, gaint *, gaint *);
 gaint decode_delta_t(char *, gaint *, gaint *, gaint *, gaint *, gaint *, gaint *);
 gaint init_standard_arrays (gaint);
 gaint gadxdf(struct gafile *, GASDFPARMS *);


### PR DESCRIPTION
This PR adds noleap (365-day) calendar support to the sdfopen command used for NetCDF files. Earlier the only way to open such files with GrADS was to create a CTL file with `OPTIONS 365_day_calendar` and a proper `TDEF` definition.

